### PR TITLE
Extend 25 : improve the plugin performance

### DIFF
--- a/src/java/fr/paris/lutece/plugins/extend/business/extender/ResourceExtenderDTOFilter.java
+++ b/src/java/fr/paris/lutece/plugins/extend/business/extender/ResourceExtenderDTOFilter.java
@@ -64,6 +64,7 @@ public class ResourceExtenderDTOFilter implements Serializable
     private static final String SQL_FILTER_ID_EXTENDER = " id_extender = ? ";
     private static final String SQL_FILTER_EXTENDER_TYPE = " extender_type = ? ";
     private static final String SQL_FILTER_ID_RESOURCE = " id_resource = ? ";
+    private static final String SQL_FILTER_ID_RESOURCE_OR_WILDCARD = " id_resource IN ( ? , '" + WILDCARD_ID_RESOURCE + "' ) ";
     private static final String SQL_FILTER_RESOURCE_TYPE = " resource_type = ? ";
 
     // SQL ORDER BY
@@ -79,6 +80,7 @@ public class ResourceExtenderDTOFilter implements Serializable
     private boolean _bIsWideSearch;
     private String _strSortedAttributeName;
     private boolean _bIsAscSort;
+    private boolean _bIncludeWildcardResource;
 
     /**
      * Instantiates a new resource extender dto filter.
@@ -246,6 +248,25 @@ public class ResourceExtenderDTOFilter implements Serializable
     }
 
     /**
+     * Set <code>true</code> if the search should include the wildcard resource ID
+     * @param includeWildcardResource <code>true</code> if the search should include the wildcard resource ID
+     */
+    public void setIncludeWildcardResource( boolean includeWildcardResource )
+    {
+        _bIncludeWildcardResource = includeWildcardResource;
+    }
+
+    /**
+     * Should the search include the wildcard resource ID
+     * @return <code>true</code> if the search should include the wildcard resource ID,
+     * <code>false</code> otherwise
+     */
+    public boolean isIncludeWildcardResource(  )
+    {
+        return _bIncludeWildcardResource;
+    }
+
+    /**
      * Gets the sorted attribute name.
      *
      * @return the sorted attribute name
@@ -308,7 +329,13 @@ public class ResourceExtenderDTOFilter implements Serializable
 
         nIndex = buildFilter( sbSQL, containsFilterIdExtender(  ), SQL_FILTER_ID_EXTENDER, nIndex );
         nIndex = buildFilter( sbSQL, containsFilterExtenderType(  ), SQL_FILTER_EXTENDER_TYPE, nIndex );
-        nIndex = buildFilter( sbSQL, containsFilterIdExtendableResource(  ), SQL_FILTER_ID_RESOURCE, nIndex );
+        if ( isIncludeWildcardResource( ) )
+        {
+            nIndex = buildFilter( sbSQL, containsFilterIdExtendableResource(  ), SQL_FILTER_ID_RESOURCE_OR_WILDCARD, nIndex );
+        } else
+        {
+            nIndex = buildFilter( sbSQL, containsFilterIdExtendableResource(  ), SQL_FILTER_ID_RESOURCE, nIndex );
+        }
         buildFilter( sbSQL, containsFilterExtendableResourceType(  ), SQL_FILTER_RESOURCE_TYPE, nIndex );
 
         if ( containsAttributeName(  ) )

--- a/src/java/fr/paris/lutece/plugins/extend/service/content/ExtendableContentPostProcessor.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/content/ExtendableContentPostProcessor.java
@@ -92,6 +92,7 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
     @Inject
     private IStringMapper<ResourceExtenderDTO> _mapper;
     private String _strRegexPattern;
+    private Pattern _regexPattern;
     private String _strExtenderParameterRegexPattern;
 
     /**
@@ -102,6 +103,11 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
     public void setRegexPattern( String strRegexPattern )
     {
         _strRegexPattern = strRegexPattern;
+        if ( _regexPattern == null || !_regexPattern.pattern( ).equals( strRegexPattern ) )
+        {
+            Pattern pattern = Pattern.compile( strRegexPattern );
+            _regexPattern = pattern;
+        }
     }
 
     /**
@@ -173,8 +179,7 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
              */
 
             // 1) First parse the content of the markers
-            Pattern pattern = Pattern.compile( _strRegexPattern );
-            Matcher match = pattern.matcher( strHtmlContent );
+            Matcher match = _regexPattern.matcher( strHtmlContent );
 
             while ( match.find(  ) )
             {

--- a/src/java/fr/paris/lutece/plugins/extend/service/content/ExtendableContentPostProcessor.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/content/ExtendableContentPostProcessor.java
@@ -186,7 +186,8 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
 
             // 1) First parse the content of the markers
             Matcher match = _regexPattern.matcher( strHtmlContent );
-
+            Matcher parameterMatch = null;
+            StringBuffer strResultHTML = new StringBuffer( strHtmlContent.length( ) );
             while ( match.find(  ) )
             {
                 String strMarker = match.group(  );
@@ -198,7 +199,12 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
 
                 if ( bParameteredId )
                 {
-                    Matcher parameterMatch = _extendedParameterRegexPattern.matcher( strHtmlContent );
+                    if ( parameterMatch == null)
+                    {
+                        parameterMatch = _extendedParameterRegexPattern.matcher( strHtmlContent );
+                    } else {
+                        parameterMatch.reset( );
+                    }
 
                     while ( parameterMatch.find(  ) )
                     {
@@ -234,14 +240,15 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
                 }
 
                 // 4) Replace the markers by the html content
-                strHtmlContent = strHtmlContent.replaceAll( Pattern.quote( strMarker ),
-                        Matcher.quoteReplacement( strHtml ) );
+                match.appendReplacement( strResultHTML, Matcher.quoteReplacement( strHtml ) );
             }
+            match.appendTail( strResultHTML );
+            strHtmlContent = strResultHTML.toString( );
         }
 
         if ( StringUtils.isNotBlank( _strExtenderParameterRegexPattern ) )
         {
-            strHtmlContent = strHtmlContent.replaceAll( _strExtenderParameterRegexPattern, "" );
+            strHtmlContent = _extendedParameterRegexPattern.matcher( strHtmlContent ).replaceAll( "" );
         }
 
         return strHtmlContent;

--- a/src/java/fr/paris/lutece/plugins/extend/service/content/ExtendableContentPostProcessor.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/content/ExtendableContentPostProcessor.java
@@ -94,6 +94,7 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
     private String _strRegexPattern;
     private Pattern _regexPattern;
     private String _strExtenderParameterRegexPattern;
+    private Pattern _extendedParameterRegexPattern;
 
     /**
      * Sets the regex pattern.
@@ -118,6 +119,11 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
     public void setExtenderParameterRegexPattern( String strExtenderParameterRegexPattern )
     {
         _strExtenderParameterRegexPattern = strExtenderParameterRegexPattern;
+        if ( _extendedParameterRegexPattern == null || !_extendedParameterRegexPattern.pattern( ).equals( strExtenderParameterRegexPattern ) )
+        {
+            Pattern pattern = Pattern.compile( strExtenderParameterRegexPattern );
+            _extendedParameterRegexPattern = pattern;
+        }
     }
 
     /**
@@ -192,8 +198,7 @@ public class ExtendableContentPostProcessor implements ContentPostProcessor, Ini
 
                 if ( bParameteredId )
                 {
-                    Pattern parameterpattern = Pattern.compile( _strExtenderParameterRegexPattern );
-                    Matcher parameterMatch = parameterpattern.matcher( strHtmlContent );
+                    Matcher parameterMatch = _extendedParameterRegexPattern.matcher( strHtmlContent );
 
                     while ( parameterMatch.find(  ) )
                     {

--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/IResourceExtenderService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/IResourceExtenderService.java
@@ -121,7 +121,7 @@ public interface IResourceExtenderService
     List<ResourceExtenderDTO> findByListIds( List<Integer> listIds );
 
     /**
-     * Find the resource extender that either has an ID.
+     * Find the resource extender.
      * @param strExtenderType the str extender type
      * @param strIdExtendableResource the str id extendable resource
      * @param strExtendableResourceType the str extendable resource type
@@ -138,6 +138,17 @@ public interface IResourceExtenderService
      * @return the resource extender dto
      */
     ResourceExtenderDTO findWildCardResourceExtender( String strExtenderType, String strExtendableResourceType );
+
+    /**
+     * Find the resource extender, or the wildcard resource extender if no
+     * extender with the specified id exists.
+     * @param strExtenderType the str extender type
+     * @param strIdExtendableResource the str id extendable resource
+     * @param strExtendableResourceType the str extendable resource type
+     * @return the resource extender dto
+     */
+    ResourceExtenderDTO findResourceExtenderIncludingWildcard( String strExtenderType, String strIdExtendableResource,
+        String strExtendableResourceType );
 
     /**
      * Gets the extender types.

--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderService.java
@@ -137,7 +137,7 @@ public class ResourceExtenderService implements IResourceExtenderService
         filter.setWideSearch( false );
         filter.setIncludeWildcardResource( true );
 
-        List<ResourceExtenderDTO> listResources = findByFilter( filter );
+        List<Integer> listResources = findIdsByFilter( filter );
 
         return ( listResources != null ) && !listResources.isEmpty(  );
     }

--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderService.java
@@ -46,6 +46,7 @@ import fr.paris.lutece.portal.service.plugin.Plugin;
 import fr.paris.lutece.portal.service.rbac.RBACService;
 import fr.paris.lutece.portal.service.resource.IExtendableResource;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
+import fr.paris.lutece.portal.service.util.AppLogService;
 import fr.paris.lutece.util.ReferenceList;
 
 import org.apache.commons.lang.StringUtils;
@@ -273,6 +274,50 @@ public class ResourceExtenderService extends AbstractCacheableService implements
         if ( ( listResources != null ) && ( listResources.size(  ) == 1 ) )
         {
             ResourceExtenderDTO resourceExtender = listResources.get( 0 );
+            resourceExtender.setName( getExtendableResourceName( resourceExtender ) );
+
+            return resourceExtender;
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResourceExtenderDTO findResourceExtenderIncludingWildcard( String strExtenderType,
+            String strIdExtendableResource, String strExtendableResourceType )
+    {
+        ResourceExtenderDTOFilter filter = new ResourceExtenderDTOFilter( strExtenderType, strIdExtendableResource,
+                strExtendableResourceType );
+        filter.setWideSearch( false );
+        filter.setIncludeWildcardResource( true );
+
+        List<ResourceExtenderDTO> listResources = findByFilter( filter );
+
+        if ( listResources != null )
+        {
+            ResourceExtenderDTO resourceExtender;
+            if ( listResources.size(  ) == 1 )
+            {
+                resourceExtender = listResources.get( 0 );
+            } else if ( listResources.size(  ) == 2 )
+            {
+                if ( listResources.get( 0 ).getIdExtendableResource( ).equals( strIdExtendableResource ) )
+                {
+                    resourceExtender = listResources.get( 0 );
+                } else
+                {
+                    resourceExtender = listResources.get( 1 );
+                }
+            } else
+            {
+                AppLogService.error( "More than 2 ResourceExtenderDTO found for "
+                        + strExtenderType + "," + strIdExtendableResource + "," + strExtendableResourceType);
+                return null;
+            }
+
             resourceExtender.setName( getExtendableResourceName( resourceExtender ) );
 
             return resourceExtender;

--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderService.java
@@ -132,16 +132,10 @@ public class ResourceExtenderService implements IResourceExtenderService
     public boolean isAuthorized( String strIdExtendableResource, String strExtendableResourceType,
         String strExtenderType )
     {
-        // First check if the wildcard '*' is defined for this resourceType and extenderType
-        if ( isAuthorizedToAllResources( strExtendableResourceType, strExtenderType ) )
-        {
-            return true;
-        }
-
-        // If no wildcard, then check for this specific id
         ResourceExtenderDTOFilter filter = new ResourceExtenderDTOFilter( strExtenderType, strIdExtendableResource,
                 strExtendableResourceType );
         filter.setWideSearch( false );
+        filter.setIncludeWildcardResource( true );
 
         List<ResourceExtenderDTO> listResources = findByFilter( filter );
 

--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/config/ResourceExtenderConfigService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/config/ResourceExtenderConfigService.java
@@ -114,14 +114,8 @@ public class ResourceExtenderConfigService implements IResourceExtenderConfigSer
     @Override
     public <T> T find( String strExtenderType, String strIdExtendableResource, String strExtendableResourceType )
     {
-        ResourceExtenderDTO resourceExtender = _extenderService.findResourceExtender( strExtenderType,
+        ResourceExtenderDTO resourceExtender = _extenderService.findResourceExtenderIncludingWildcard( strExtenderType,
                 strIdExtendableResource, strExtendableResourceType );
-
-        if ( resourceExtender == null )
-        {
-            // Check if the resource extender has an ID resource '*'
-            resourceExtender = _extenderService.findWildCardResourceExtender( strExtenderType, strExtendableResourceType );
-        }
 
         if ( resourceExtender != null )
         {


### PR DESCRIPTION
Reduce the number of queries, use a cache, make a more efficient use of regexps.

Tested by setting up a bare Lutece with a hit extender on the front page,
then using the command :
ab -c 2 -n 50000 http://localhost:8080/lutece/

9645f01 gives 304.86 requests/second.
This PR gives 1120.96 requests/second, or a 367% improvement.

Also tested by setting up a bare Lutece with a opengraph extender on page *,
then using the command :
ab -c 2 -n 50000 http://localhost:8080/lutece/

commit ba853b0 gives 493.34 requests/second.
This PR gives 742.68 requests/second, or a 50.5% improvement.
