### PR TITLE
EXTEND-26 : cache ExtenderConfigs

### DIFF
--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/IResourceExtenderCacheService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/IResourceExtenderCacheService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2016, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.extend.service.extender;
+
+import fr.paris.lutece.portal.service.cache.CacheableService;
+
+/**
+ * Cache service interface for Extender
+ */
+public interface IResourceExtenderCacheService extends CacheableService
+{
+
+    /**
+     * Get an obect from the cache
+     * @param strKey the key
+     * @return the corresponding object, or <code>null</code> if it is absent from the cache
+     */
+    Object getFromCache( String strKey );
+
+    /**
+     * Put an object in cache
+     * @param strKey the key
+     * @param value the object to cache
+     */
+    void putInCache( String strKey, Object value );
+
+}

--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/IResourceExtenderCacheService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/IResourceExtenderCacheService.java
@@ -55,4 +55,10 @@ public interface IResourceExtenderCacheService extends CacheableService
      */
     void putInCache( String strKey, Object value );
 
+    /**
+     * Removes a cache element
+     * @param strKey the key
+     */
+    void removeKey( String strKey );
+
 }

--- a/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderCacheService.java
+++ b/src/java/fr/paris/lutece/plugins/extend/service/extender/ResourceExtenderCacheService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2016, Mairie de Paris
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice
+ *     and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice
+ *     and the following disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ *  3. Neither the name of 'Mairie de Paris' nor 'Lutece' nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * License 1.0
+ */
+package fr.paris.lutece.plugins.extend.service.extender;
+
+import fr.paris.lutece.portal.service.cache.AbstractCacheableService;
+
+/**
+ * Cache service for Extender
+ */
+public class ResourceExtenderCacheService extends AbstractCacheableService implements IResourceExtenderCacheService
+{
+
+    private static final String CACHE_NAME = "Extender Service Cache";
+
+    /**
+     * Constructor. Inits the cache.
+     */
+    ResourceExtenderCacheService(  )
+    {
+        initCache( getName(  ) );
+    }
+
+    @Override
+    public String getName( )
+    {
+        return CACHE_NAME;
+    }
+
+}

--- a/webapp/WEB-INF/conf/plugins/extend_context.xml
+++ b/webapp/WEB-INF/conf/plugins/extend_context.xml
@@ -24,6 +24,7 @@
 	<bean id="extend.createExtenderFromResourceAction" class="fr.paris.lutece.plugins.extend.web.action.CreateExtenderFromResourcePluginAction" />
 	
 	<!-- Services -->
+	<bean id="extend.resourceExtenderCacheService" class="fr.paris.lutece.plugins.extend.service.extender.ResourceExtenderCacheService" />
 	<bean id="extend.resourceExtenderService" class="fr.paris.lutece.plugins.extend.service.extender.ResourceExtenderService" />
 	<bean id="extend.extendableResourceTypeService" class="fr.paris.lutece.plugins.extend.service.type.ExtendableResourceTypeService" />
 	<bean id="extend.extenderStringMapper" class="fr.paris.lutece.plugins.extend.service.converter.ExtenderStringMapper"


### PR DESCRIPTION
Tested on a bare Lutece with an opengraph extender on page \* with no
social networks configured, wuth the command:

ab -c 2 -n 50000 http://localhost:8080/lutece/

Before : 729.99 reqs/s
After  : 942.13 reqs/s

Or a 29% improvment.
